### PR TITLE
fix: incorrectly decoded aws secret key that containts + sign

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
 group = "io.magj"
 
 val release: String? by project
-val baseVersion = "0.1.6"
+val baseVersion = "0.1.7"
 
 version = if (release != null && release!!.toBoolean()) {
     baseVersion

--- a/src/main/java/io/magj/iamjdbcdriver/IamAuthJdbcDriverWrapper.java
+++ b/src/main/java/io/magj/iamjdbcdriver/IamAuthJdbcDriverWrapper.java
@@ -198,9 +198,15 @@ public class IamAuthJdbcDriverWrapper implements Driver {
                 continue;
             }
             try {
+                // AWS secret key can contain + sign and URLDecoder will replace + or %20 with space
+                // which will render the access key unusable (if it wasn't encoded before)
+                // RFC2396 allows + sign in schema URI so as a workaround we will replace + with its
+                // encoded counterpart
                 queryParams.put(
                         URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8.name()),
-                        URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8.name()));
+                        URLDecoder.decode(
+                                pair.substring(idx + 1).replace("+", "%2B"),
+                                StandardCharsets.UTF_8.name()));
             } catch (UnsupportedEncodingException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
This will fix aws secret keys that contain `+` sign as mentioned in #1 