### PR TITLE
Add STS SDK as a dependency for profile role assumptions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ repositories {
 
 dependencies {
     implementation("com.amazonaws:aws-java-sdk-rds:1.11.745")
+    implementation("com.amazonaws:aws-java-sdk-sts:1.11.745")
     testImplementation("junit:junit:3.8.1")
     testImplementation("org.postgresql:postgresql:42.2.12")
 }
@@ -21,7 +22,7 @@ dependencies {
 group = "io.magj"
 
 val release: String? by project
-val baseVersion = "0.1.7"
+val baseVersion = "0.1.8"
 
 version = if (release != null && release!!.toBoolean()) {
     baseVersion


### PR DESCRIPTION
Hey,

if user attempts a cross account login with assume role (`role_arn` in credentials file) AWS SDK will throw `io.magj.iamjdbcdriver.repackaged.com.amazonaws.SdkClientException: To use assume role profiles the aws-java-sdk-sts module must be on the class path.`

So this PR will add AWS STS SDK as a dependency. 

I dont think its necessary to add the `role_arn` and `source_profile` to connection query paramaters due to this old, still [unresolved issue](https://github.com/aws/aws-sdk-java/issues/803) in java SDK. 